### PR TITLE
delete "window.port" from websocket destination uri

### DIFF
--- a/app/components/tty.js
+++ b/app/components/tty.js
@@ -78,8 +78,7 @@
 
         var init_socket;
         init_socket = function (atty) {
-            atty.socket = new WebSocket('ws://' + window.location.host + (window.location.port ? ":" + window.location.port: '') +
-                                       "/api/0.1.0/vms/" + uuid + "/console");
+            atty.socket = new WebSocket('ws://' + window.location.host + "api/0.1.0/vms/" + uuid + "/console");
             setInterval(function () {
                 atty.socket.send("");
             }, 5000);


### PR DESCRIPTION
`window.host` includes the port number.
So `window.port` must NOT be included in the websocket destination uri.
