### PR TITLE
show lang selector with locale's real name (in unicode)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -44,6 +44,7 @@
     <script src="scripts/config.js"></script>
     <!-- build:js scripts/main.js -->
     <script src="scripts/app.js"></script>
+    <script src="scripts/langMap.js"></script>
     <script src="scripts/lang.js"></script>
 
     <script src="scripts/services/wiggle.js"></script>

--- a/app/scripts/controllers/header.js
+++ b/app/scripts/controllers/header.js
@@ -49,16 +49,21 @@ angular.module('fifoApp')
   	})
 
     //Language
-    $scope.lang = gettextCatalog.currentLanguage;
-    $scope.setLang = function(lang) {
-      $scope.lang = gettextCatalog.currentLanguage = lang;
+    var curLocale = gettextCatalog.currentLanguage;
+    $scope.lang = { name: langMap[curLocale.toLowerCase()], locale: curLocale };
+    $scope.setLang = function(locale) {
+      gettextCatalog.currentLanguage = locale;
+      $scope.lang = { name: langMap[locale.toLowerCase()], locale: locale };
     }
     var langs = Object.keys(gettextCatalog.strings);
 
     //Put the default lang, the others are automatically added
     if (langs.indexOf('en')<1) langs.push('en');
 
-    $scope.languages = langs.sort();
+    $scope.languages = [];
+    langs.sort().forEach(function(locale) {
+      $scope.languages.push({ name: langMap[locale.toLowerCase()] || locale, locale: locale });
+    });
 
     //Backend selector
     $scope.changeBackend = function(back, idx) {

--- a/app/scripts/langMap.js
+++ b/app/scripts/langMap.js
@@ -1,0 +1,7 @@
+var langMap = {
+// locale(lowercase): name
+  'en': 'English',
+  'es': 'España',
+  'zh-cn': '简体中文',
+  'zh-tw': '繁体中文'
+};

--- a/app/views/partials/header.html
+++ b/app/views/partials/header.html
@@ -52,11 +52,11 @@
                     </ul>
                 </li>
                 <li class='dropdown' title='Language'>
-                    <a class="dropdown-toggle capitalize" data-toggle='dropdown'>{{lang}}</a>
+                    <a class="dropdown-toggle capitalize" data-toggle='dropdown'>{{lang.name}}</a>
                     <ul class="dropdown-menu" role='menu'>
                         <li ng-repeat='lang in languages'>
-                            <a ng-click="setLang(lang)">
-                                <span class='capitalize'>&nbsp;&nbsp;{{lang}}</span>
+                            <a ng-click="setLang(lang.locale)">
+                                <span class='capitalize'>&nbsp;&nbsp;{{lang.name}}</span>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
e.g., now defaultly it will show 'English' in header, and show 'English', 'España', '简体中文', '繁体中文' in dropdown menu.

lang and its name mapping is defined in scripts/langMap.js, in the format
{
   lang_in_lowercase: unicode_name
}

if there can not find any mapping in langMap, the locale will be used.
